### PR TITLE
Add support to output png files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [Demo][demo] | [Tutorial][book]
 
 The `wavedrom-rs` crate provides an interface to shape beautiful [Digital Timing
-Diagrams][dtd] into an [SVG][svg]. It is almost completely compatible with the
+Diagrams][dtd] into a [SVG][svg] or [PNG][png] file. It is almost completely compatible with the
 [WaveDrom][wavedrom-js] project. It can be merged into document build tools,
 continuous integration or be used as a one off to generate beautiful
 diagrams.
@@ -84,6 +84,7 @@ Licensed under a [MIT License](./LICENSE). The demo website utilizes icons from
 
 [demo]: https://gburghoorn.com/wavedrom
 [svg]: https://en.wikipedia.org/wiki/SVG
+[png]: https://en.wikipedia.org/wiki/PNG
 [wavedrom-js]: https://wavedrom.com/
 [tutorial]: https://wavedrom.com/tutorial.html
 [lucide]: https://lucide.dev/

--- a/wavedrom/Cargo.toml
+++ b/wavedrom/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.4.1"
 optional = true
 
 [dependencies.ttf-parser]
-version = "0.19.0"
+version = "0.20.0"
 optional = true
 
 [dependencies.serde]
@@ -32,7 +32,7 @@ version = "1.0"
 optional = true
 
 [dependencies.arbitrary]
-version = "1.3.0"
+version = "1.3.2"
 optional = true
 features = ["derive"]
 

--- a/wavedrom/Cargo.toml
+++ b/wavedrom/Cargo.toml
@@ -36,6 +36,15 @@ version = "1.3.0"
 optional = true
 features = ["derive"]
 
+
+[dependencies.resvg]
+version = "0.37.0"
+
+
+[dependencies.usvg]
+version = "0.37.0"
+
+
 [features]
 default = ["json5", "embed_font", "skins"]
 embed_font = ["dep:ttf-parser"]

--- a/wavedrom/src/signal/mod.rs
+++ b/wavedrom/src/signal/mod.rs
@@ -11,7 +11,6 @@ mod render;
 pub use cycle_offset::{CycleOffset, InCycleOffset};
 pub use figure::{SignalFigure, SignalFigureSection, SignalFigureSectionGroup};
 pub use path::*;
-pub use render::*;
 
 use std::num::NonZeroU16;
 


### PR DESCRIPTION
Add support to output PNG files.

- A PNG file is output if command line parameter -o *.png is given
- A SVG file is output if command line parameter -o *.svg is given
- A SVG file is still written to stdout if parameter -o is not given
- If the file ending is not known, an error is presented
